### PR TITLE
Fix bug where album was not showing on Songs pages

### DIFF
--- a/musicrush/Pages/Albums/Details.cshtml
+++ b/musicrush/Pages/Albums/Details.cshtml
@@ -37,12 +37,10 @@
             @Html.DisplayNameFor(model => model.Album.Rating)
         </dt>
         <dd class="col-sm-10">
-
-            
             @{
                 var albumStarRating = new String( '✭', this.Model.Album.Rating ?? 0);
             }
-                            @albumStarRating
+            @albumStarRating
             (@Html.DisplayFor(model => model.Album.Rating))        
         </dd>
         <dt class="col-sm-2">
@@ -61,8 +59,11 @@
                             @Html.DisplayFor(modelItem => item.Title)
                         </td>
                         <td>
-@*                              *@
-                            @Html.DisplayFor(modelItem => item.Rating)
+                            @{
+                               var songstarRating = new String( '✭', item.Rating ?? 0);
+                            }
+                            @songstarRating
+                            (@Html.DisplayFor(modelItem => item.Rating))
                         </td>
                     </tr>
                 }

--- a/musicrush/Pages/Albums/Details.cshtml
+++ b/musicrush/Pages/Albums/Details.cshtml
@@ -37,9 +37,15 @@
             @Html.DisplayNameFor(model => model.Album.Rating)
         </dt>
         <dd class="col-sm-10">
-            @Html.DisplayFor(model => model.Album.Rating)
+
+            
+            @{
+                var albumStarRating = new String( '✭', this.Model.Album.Rating ?? 0);
+            }
+                            @albumStarRating
+            (@Html.DisplayFor(model => model.Album.Rating))        
         </dd>
-                <dt class="col-sm-2">
+        <dt class="col-sm-2">
             @Html.DisplayNameFor(model => model.Album.Songs)
         </dt>
         <dd class="col-sm-10">
@@ -48,15 +54,6 @@
                     <th>Song Title</th>
                     <th>Song Rating</th>
                 </tr>
-                @* <tr>
-                    <td>
-                        @Html.DisplayFor(x => this.Model.Album)
-                    </td>
-                    <td>
-                        test: @Html.DisplayFor(x => Model.Album.Songs[0]) *@
-                        @* @Html.DisplayFor(modelItem => item.Artist) *@
-                    @* </td>
-                </tr> *@
                 @foreach (var item in this.Model.Album.Songs)
                 {
                     <tr>
@@ -64,6 +61,7 @@
                             @Html.DisplayFor(modelItem => item.Title)
                         </td>
                         <td>
+@*                              *@
                             @Html.DisplayFor(modelItem => item.Rating)
                         </td>
                     </tr>

--- a/musicrush/Pages/Albums/Details.cshtml.cs
+++ b/musicrush/Pages/Albums/Details.cshtml.cs
@@ -20,6 +20,8 @@ namespace musicrush.Pages.Albums
 
         public Album Album { get; set; }
 
+        // public String StarRating { get; set; }
+
         public async Task<IActionResult> OnGetAsync(int? id)
         {
             if (id == null)
@@ -36,6 +38,9 @@ namespace musicrush.Pages.Albums
             {
                 return NotFound();
             }
+
+            // StarRating = new String( '✭', Album.Rating ?? 0);
+            
             return Page();
         }
     }

--- a/musicrush/Pages/Albums/Index.cshtml
+++ b/musicrush/Pages/Albums/Index.cshtml
@@ -76,7 +76,11 @@
                     @Html.DisplayFor(modelItem => item.Artist)
                 </td>
                 <td>
-                    @Html.DisplayFor(modelItem => item.Rating)
+                    @{
+                        var albumStarRating = new String( '✭', item.Rating ?? 0);
+                    }
+                    @albumStarRating
+                    (@Html.DisplayFor(modelItem => item.Rating))
                 </td>
                 <td>
                     <a asp-page="./Edit" asp-route-id="@item.ID">Edit</a> |

--- a/musicrush/Pages/Songs/Details.cshtml
+++ b/musicrush/Pages/Songs/Details.cshtml
@@ -39,7 +39,7 @@
             @Html.DisplayNameFor(model => model.Song.Album)
         </dt>
         <dd class="col-sm-10">
-            @Html.DisplayFor(model => model.Song.Album)
+            @Html.DisplayFor(model => model.Song.Album.Title)
         </dd>
         <dt class="col-sm-2">
             @Html.DisplayNameFor(model => model.Song.Rating)

--- a/musicrush/Pages/Songs/Details.cshtml
+++ b/musicrush/Pages/Songs/Details.cshtml
@@ -45,7 +45,11 @@
             @Html.DisplayNameFor(model => model.Song.Rating)
         </dt>
         <dd class="col-sm-10">
-            @Html.DisplayFor(model => model.Song.Rating)
+            @{
+                var songStarRating = new String( '✭', this.Model.Song.Rating ?? 0);
+            }
+            @songStarRating
+            (@Html.DisplayFor(model => model.Song.Rating))        
         </dd>
     </dl>
 </div>

--- a/musicrush/Pages/Songs/Details.cshtml.cs
+++ b/musicrush/Pages/Songs/Details.cshtml.cs
@@ -19,6 +19,7 @@ namespace musicrush.Pages.Songs
         }
 
         public Song Song { get; set; }
+        public Album Album { get; set; }
 
         public async Task<IActionResult> OnGetAsync(int? id)
         {
@@ -27,7 +28,10 @@ namespace musicrush.Pages.Songs
                 return NotFound();
             }
 
-            Song = await _context.Songs.FirstOrDefaultAsync(m => m.ID == id);
+            Song = await _context
+                            .Songs
+                            .Include(a => a.Album)
+                            .FirstOrDefaultAsync(m => m.ID == id);
 
             if (Song == null)
             {

--- a/musicrush/Pages/Songs/Edit.cshtml
+++ b/musicrush/Pages/Songs/Edit.cshtml
@@ -35,11 +35,6 @@
                 <span asp-validation-for="Song.Artist" class="text-danger"></span>
             </div>
             <div class="form-group">
-                <label asp-for="Song.Album" class="control-label"></label>
-                <input asp-for="Song.Album" class="form-control" />
-                <span asp-validation-for="Song.Album" class="text-danger"></span>
-            </div>
-            <div class="form-group">
                 <label asp-for="Song.Rating" class="control-label"></label>
                 <input asp-for="Song.Rating" class="form-control" type="number" min="0" max="5" />
                 <span asp-validation-for="Song.Rating" class="text-danger"></span>

--- a/musicrush/Pages/Songs/Index.cshtml
+++ b/musicrush/Pages/Songs/Index.cshtml
@@ -20,26 +20,7 @@
     <button type="submit" value="Search" class="text-dark search-btn"><i class="fas fa-search"></i></button>
 </form>
 <table class="table">
-    @* <thead>
-        <tr>
-        <th>
-        @Html.DisplayNameFor(model => model.Song[0].Title)
-        </th>
-        <th>
-        @Html.DisplayNameFor(model => model.Song[0].ReleaseDate)
-        </th>
-        <th>
-        @Html.DisplayNameFor(model => model.Song[0].Genre)
-        </th>
-        <th>
-        @Html.DisplayNameFor(model => model.Song[0].Artist)
-        </th>
-        <th>
-        @Html.DisplayNameFor(model => model.Song[0].Album)
-        </th>
-        <th></th>
-        </tr>
-        </thead> *@
+
     <div class="wrapper">
         @foreach (var item in Model.Song)
         {
@@ -61,17 +42,17 @@
                                     @Html.DisplayFor(modelItem => item.Genre)
                                     </span></div> *@
                                 <span class="card-text">
-                                    @Html.DisplayFor(modelItem => item.Artist)
+                                    Artist: @Html.DisplayFor(modelItem => item.Artist)
                                 </span>
-                                @* <div class="col-2 text-box"><span>
-                                    @Html.DisplayFor(modelItem => item.Album)
-                                    </span>
-                                    </div>*@
                                 @* <span>
                                     <a asp-page="./Edit" asp-route-id="@item.ID">Edit</a> |
                                     <a asp-page="./Details" asp-route-id="@item.ID">Details</a> |
                                     <a asp-page="./Delete" asp-route-id="@item.ID">Delete</a>
                                     </span> *@
+                                <p class="album">
+                                Album: @item.Album.Title
+                                </p>
+
                                 <p class="rating">
                                     Rating: @Html.DisplayFor(modelItem => item.Rating)/5
                                 </p>

--- a/musicrush/Pages/Songs/Index.cshtml.cs
+++ b/musicrush/Pages/Songs/Index.cshtml.cs
@@ -26,7 +26,7 @@ namespace musicrush.Pages.Songs
         public string SongGenre { get; set; }
 
         public async Task OnGetAsync()
-        {
+        {     
             IQueryable<string> genreQuery = from s in _context.Songs
                                             orderby s.Genre
                                             select s.Genre;
@@ -41,7 +41,9 @@ namespace musicrush.Pages.Songs
                 songs = songs.Where(x => x.Genre == SongGenre);
             }
             Genres = new SelectList(await genreQuery.Distinct().ToListAsync());
-            Song = await songs.ToListAsync();
+            Song = await songs
+                            .Include(s => s.Album)
+                            .ToListAsync();
         }
     }
 }


### PR DESCRIPTION
Implemented `Include()` to show Album Album on the Songs page, added stars in place of ratings on the Albums details page.